### PR TITLE
Добавил удобную библиотеку для транзакций. Для того чтобы можно было удобно писать бизнес логику и не нужно было реализовывать большую транзакцию на уровне репозитория.

### DIFF
--- a/apps/gateway/src/gateway.service.ts
+++ b/apps/gateway/src/gateway.service.ts
@@ -1,11 +1,15 @@
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
-import { PrismaClient, User } from '@prisma/gateway';
+import { User } from '@prisma/gateway';
 
 @Injectable()
 export class GatewayService {
-  constructor(private readonly prisma: PrismaClient) { }
+  constructor(
+    private readonly txHost: TransactionHost<TransactionalAdapterPrisma>,
+  ) { }
   async getUsers(): Promise<User[]> {
-    const user = await this.prisma.user.findMany();
+    const user = await this.txHost.tx.user.findMany();
     return user;
   }
 }

--- a/libs/databases/src/gateway/gateway-prisma.module.ts
+++ b/libs/databases/src/gateway/gateway-prisma.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { GatewayPrismaService } from './gateway-prisma.service';
+
+@Module({
+  providers: [GatewayPrismaService],
+  exports: [GatewayPrismaService],
+})
+export class GatewayPrismaModule { }

--- a/libs/databases/src/gateway/gateway-prisma.service.ts
+++ b/libs/databases/src/gateway/gateway-prisma.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '@prisma/gateway';
+import { PrismaClient as GatewayPrismaClient } from '@prisma/gateway';
 
 @Injectable()
-export class GatewayDatabaseClient
-  extends PrismaClient
+export class GatewayPrismaService
+  extends GatewayPrismaClient
   implements OnModuleInit {
   async onModuleInit(): Promise<void> {
     await this.$connect();

--- a/package.json
+++ b/package.json
@@ -27,12 +27,15 @@
     "start:gateway": "NODE_ENV=production node dist/apps/gateway/main"
   },
   "dependencies": {
+    "@nestjs-cls/transactional": "^2.4.0",
+    "@nestjs-cls/transactional-adapter-prisma": "^1.2.2",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.0.0",
     "@nestjs/microservices": "^10.3.10",
     "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "5.16.1",
+    "nestjs-cls": "^4.3.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -679,6 +679,16 @@
   resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
   integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
 
+"@nestjs-cls/transactional-adapter-prisma@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@nestjs-cls/transactional-adapter-prisma/-/transactional-adapter-prisma-1.2.2.tgz#658db8de2badfda5166e0529e42f08927bcd16b6"
+  integrity sha512-Z6arx88uvQ78plmM+igLXeSJk2J6fEUwnBqbGMhIweamQScFhvmLvSi6T13WIwyCb7tVZ8vAY3yerOSLLiojeA==
+
+"@nestjs-cls/transactional@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@nestjs-cls/transactional/-/transactional-2.4.0.tgz#763a6cdc0da4d96713bc2a46ff556102f335f2e4"
+  integrity sha512-ZwkA9winTuzDBzQ/ln2+kEP7XbxXCqGhAMiHZwZcbO8r48d3K59XiXhbhsgYbEx/JTTORKu4nooA591hk6bCUQ==
+
 "@nestjs/cli@^10.0.0":
   version "10.3.2"
   resolved "https://registry.yarnpkg.com/@nestjs/cli/-/cli-10.3.2.tgz#42d2764ead6633e278c55d42de871b4cc1db002b"
@@ -3778,6 +3788,11 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+nestjs-cls@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/nestjs-cls/-/nestjs-cls-4.3.0.tgz#1d8e8f5db8557392c6c8ff1eafd590e5d11d7815"
+  integrity sha512-MVTun6tqCZih8AJXRj8uBuuFyJhQrIA9m9fStiQjbBXUkE3BrlMRvmLzyw8UcneB3xtFFTfwkAh5PYKRulyaOg==
 
 node-abort-controller@^3.0.1:
   version "3.1.1"


### PR DESCRIPTION
Теперь можно писать следующим образом:
```typescript
import { Transactional, TransactionHost } from "@nestjs-cls/transactional";
import { TransactionalAdapterPrisma } from "@nestjs-cls/transactional-adapter-prisma";
import { Injectable } from "@nestjs/common";
import { User } from "@prisma/gateway";

@Injectable()
export class GatewayService {
  constructor(
    private readonly txHost: TransactionHost<TransactionalAdapterPrisma>,
  ) {}
  @Transactional()
  async getUsers(): Promise<User[]> {
    await this.txHost.tx.user.create({
      data: {
        name: "Alice",
        position: "Software Engineer",
      },
    });
    await this.txHost.tx.user.create({
      data: {
        name: "Bob",
        position: "Farmer",
      },
    });
    const user = await this.txHost.tx.user.findMany();
    return user;
  }
}
```
Декоратор `@Transactional()` оборачивавает метод в транзакцию, если случится ошибка, то случится rollback.
Также теперь везде нужно использовать txHost вместо PrismaService. Вместо PrismaServcie нужно делать inject `txHost` и обращаться к `txHost.tx.(someModel).(someMethod)`. Если мы не находимся в Transactional месте и обращаемся к txHost, то просто выполнится метод как обычно.
Также вместо декоратора `@Transactional()` можно использовать `txHost.withTransaction`
```typescript
    async createUser(name: string): Promise<User> {
        return this.txHost.withTransaction(async () => {
            const user = await this.txHost.tx.user.create({ data: { name } });
            await this.accountService.createAccountForUser(user.id);
            return user;
        });
    }
```
